### PR TITLE
update to 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.2.2" %}
 
 package:
   name: pywin32-ctypes
@@ -6,34 +6,40 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pywin32-ctypes/pywin32-ctypes-{{ version }}.tar.gz
-  sha256: 24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942
+  sha256: 3426e063bdd5fd4df74a14fa3cf80a0b42845a87e1d1e81f6549f9daec593a60
 
 build:
-  number: 1000
-  skip: True  # [not win]
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 0
+  skip: True  # [not win or py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - win32ctypes
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/enthought/pywin32-ctypes
-  license: BSD 3 Clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  summary: 'A limited subset of pywin32 re-implemented using ctypes (or cffi)'
+  summary: A limited subset of pywin32 re-implemented using ctypes (or cffi)
   description: |
     A reimplementation of pywin32 that is pure python. The default behaviour
     will try to use cffi (>= 1.3.0), if available, and fall back to using ctypes.
-  doc_url: http://pywin32-ctypes.readthedocs.io/en/stable/
+  doc_url: https://pywin32-ctypes.readthedocs.io
   dev_url: https://github.com/enthought/pywin32-ctypes
 
 extra:


### PR DESCRIPTION
Changes:
- update to 0.2.2

Reason: keyring's tests fail on Windows with python 3.12.
see comment from keyring author: https://github.com/python/cpython/issues/105914#issuecomment-1603682988

https://github.com/enthought/pywin32-ctypes